### PR TITLE
動画の輝度取得計算方法を修正

### DIFF
--- a/BlightnessPlayer.xcodeproj/project.pbxproj
+++ b/BlightnessPlayer.xcodeproj/project.pbxproj
@@ -445,7 +445,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = FKX54925F6;
 				INFOPLIST_FILE = BlightnessPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.garakuta-factory.BlightnessPlayer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -460,7 +460,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = FKX54925F6;
 				INFOPLIST_FILE = BlightnessPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.garakuta-factory.BlightnessPlayer";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/BlightnessPlayer/ViewController.swift
+++ b/BlightnessPlayer/ViewController.swift
@@ -155,7 +155,13 @@ class ViewController: UIViewController, AVCaptureVideoDataOutputSampleBufferDele
           // キャプチャしたsampleBufferからUIImageを作成
           let image:UIImage = self.captureImage(sampleBuffer)
           
-          let color = image.getPixelColor(CGPointMake(0, 0))
+          // 画像を1*1サイズにリサイズする(全画面を輝度計算すると重いので)
+          let resizedSize = CGSize(width: 1, height: 1)
+          UIGraphicsBeginImageContext(resizedSize)
+          image.drawInRect(CGRect(x: 0, y: 0, width: 1, height: 1))
+          let resizedImage = UIGraphicsGetImageFromCurrentImageContext()
+          
+          let color = resizedImage!.getPixelColor(CGPointMake(0, 0))
           let luminance = ( 0.298912 * color.0 + 0.586611 * color.1 + 0.114478 * color.2 );    // rgb->輝度
           
           // カメラの画像を画面に表示、輝度表示更新


### PR DESCRIPTION
・動画の輝度を取得する箇所を左上(0,0)としていたが、画像を1,1サイズに圧縮した後その値を輝度とするように修正。
・対応iOSverを9.3まで引き下げ。
(それ以降はコード内でバージョンによるかき分けが必要)
